### PR TITLE
Speed up startup time by introducing julia_args.jl

### DIFF
--- a/scripts/unix/asysimg
+++ b/scripts/unix/asysimg
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-JULIA_EXE=julia     # or [INSERT-YOUR-PATH]/julia
-asysimg_args=`$JULIA_EXE -e "using AutoSysimages; print(julia_args()); exit();" "$@"`
-$JULIA_EXE $asysimg_args "$@"

--- a/scripts/windows/asysimg.bat
+++ b/scripts/windows/asysimg.bat
@@ -1,3 +1,0 @@
-@echo off
-for /f "tokens=1-4" %%i in ('julia.exe -e "using AutoSysimages; print(julia_args()); exit()"') do set A=%%i %%j %%k %%l 
-@"%~dp0\julia.exe" %A% %*

--- a/src/AutoSysimages.jl
+++ b/src/AutoSysimages.jl
@@ -405,13 +405,33 @@ Feel free to submit a PR."""
     (os, file_name) = Sys.iswindows() ? ("windows", "asysimg.bat") : ("unix", "asysimg")
     source = joinpath(@__DIR__, "..", "scripts", os, file_name)
     source = abspath(normpath(source))
-    cp(source, joinpath(dir, file_name), force = true)
+    julia_bin = unsafe_string(Base.JLOptions().julia_bin)
+    julia_args_file = joinpath(@__DIR__, "julia_args.jl")
+    script_file = joinpath(dir, file_name)
+    txt = if Sys.iswindows()
+"""@echo off
+set JULIA=$julia_bin
+for /f "tokens=1-4" %%i in ('%JULIA% -e "using AutoSysimages; print(julia_args()); exit()" %*') do set A=%%i %%j %%k %%l
+%JULIA% %A% %*
+"""
+    else
+"""#!/usr/bin/env bash
+JULIA=$julia_bin
+asysimg_args=`\$JULIA -L $julia_args_file "\$@"`
+\$JULIA \$asysimg_args "\$@"
+"""
+    end
+    open(script_file, "w") do file
+        write(file, txt)
+    end
 
     if isinteractive()
-        @info """AutoSysimages: The `asysimg` script was copied to:
-$(dir)
+        @info """AutoSysimages: The `asysimg` is located here:
+$(script_file)
 
-Now you can run `asysimg` in terminal (instead of `julia`)"""
+Now you can run `asysimg` in terminal (instead of `julia`)
+
+"""
     end
 
     if !dir_exists

--- a/src/AutoSysimages.jl
+++ b/src/AutoSysimages.jl
@@ -411,7 +411,7 @@ Feel free to submit a PR."""
     txt = if Sys.iswindows()
 """@echo off
 set JULIA=$julia_bin
-for /f "tokens=1-4" %%i in ('%JULIA% -e "using AutoSysimages; print(julia_args()); exit()" %*') do set A=%%i %%j %%k %%l
+for /f "tokens=1-4" %%i in ('%JULIA% -L $julia_args_file %*') do set A=%%i %%j %%k %%l
 %JULIA% %A% %*
 """
     else

--- a/src/julia_args.jl
+++ b/src/julia_args.jl
@@ -1,0 +1,16 @@
+# This mimics the `julia_args` function for fast startup.
+# It needs to be kept in sync with the functions!
+
+projpath = Base.active_project()
+hash_name = string(Base._crc32c(projpath), base = 62, pad = 6)
+adir = joinpath(DEPOT_PATH[1], "asysimg", "$VERSION", hash_name)
+if isdir(adir)
+    files = readdir(adir, join = true)
+    sysimages = filter(x -> endswith(x, ".so"), files) |> sort
+    image =  isempty(sysimages) ? nothing : sysimages[end]
+    startfile = joinpath(@__DIR__, "start.jl")
+    println((isnothing(image) ? "" : " -J $image") * " -L $startfile")
+    exit()
+else
+    exit(1)
+end


### PR DESCRIPTION
This is a next step to reduce the loading time (see #20) by introducing a standalone script `julia_args.jl` that is much faster to run to obtain the correct arguments. 

As a side effect, it simplifies `install()` and removes `scripts` directory.