### PR TITLE
Disable startup file when selecting arguments in asysimg

### DIFF
--- a/src/AutoSysimages.jl
+++ b/src/AutoSysimages.jl
@@ -411,13 +411,13 @@ Feel free to submit a PR."""
     txt = if Sys.iswindows()
 """@echo off
 set JULIA=$julia_bin
-for /f "tokens=1-4" %%i in ('%JULIA% -L $julia_args_file') do set A=%%i %%j %%k %%l
+for /f "tokens=1-4" %%i in ('%JULIA% --startup-file=no -L $julia_args_file') do set A=%%i %%j %%k %%l
 %JULIA% %A% %*
 """
     else
 """#!/usr/bin/env bash
 JULIA=$julia_bin
-asysimg_args=`\$JULIA -L $julia_args_file "\$@"`
+asysimg_args=`\$JULIA --startup-file=no -L $julia_args_file "\$@"`
 \$JULIA \$asysimg_args "\$@"
 """
     end


### PR DESCRIPTION
Based on the question in forum [here](https://discourse.julialang.org/t/autosysimages-jl-automate-user-specific-system-images/87359/26), I realized that startup file is called twice. Once when getting arguments in `julia_args.jl` and then when sysimage is loaded. This PR disables the first case because it may interfere, slow down the loading and produce additional problems.