### PR TITLE
Improve startup info

### DIFF
--- a/src/AutoSysimages.jl
+++ b/src/AutoSysimages.jl
@@ -130,16 +130,18 @@ function start()
         end
     end
     atexit(_atexit)
-    txt = "The package AutoSysimages.jl started!"
-    if is_asysimg
-        txt *= "\n Loaded sysimage:    $loaded_image"
-    else
-        txt *= "\n Loaded sysimage:    Default (You may run AutoSysimages.build_sysimage())"
+    if Base.JLOptions().quiet == 0 # Disabled when `-q` argument is used
+        txt = "The package AutoSysimages.jl started!"
+        if is_asysimg
+            txt *= "\n Loaded sysimage:    $loaded_image"
+        else
+            txt *= "\n Loaded sysimage:    Default (You may run AutoSysimages.build_sysimage())"
+        end
+        txt *= "\n Active directory:   $(active_dir())"
+        txt *= "\n Global snoop file:  $precompiles_file"
+        txt *= "\n Tmp. snoop file:    $(Snooping.snoop_file)"
+        @info txt
     end
-    txt *= "\n Active directory:   $(active_dir())"
-    txt *= "\n Global snoop file:  $precompiles_file"
-    txt *= "\n Tmp. snoop file:    $(Snooping.snoop_file)"
-    @info txt
     if isinteractive()
         _update_prompt()
         is_asysimg && _warn_outdated()

--- a/src/AutoSysimages.jl
+++ b/src/AutoSysimages.jl
@@ -131,7 +131,14 @@ function start()
     end
     atexit(_atexit)
     if Base.JLOptions().quiet == 0 # Disabled when `-q` argument is used
-        txt = "The package AutoSysimages.jl started!"
+        version = pkgversion(AutoSysimages)
+        dev = ""
+        for (_, info) in Pkg.dependencies()
+            if info.name == "AutoSysimages" && info.is_tracking_path
+                dev = " \`$(info.source)\`"
+            end
+        end
+        txt = "AutoSysimages v$version$dev"
         if is_asysimg
             txt *= "\n Loaded sysimage:    $loaded_image"
         else


### PR DESCRIPTION
The goal is to improve startup information as mentioned in #20.

**Improvements**:
- [x] Disabled when `-q` argument is used
- [x] Show AutoSysimage version
- [x] Show if AutoSysimage is in `dev` mode
- [ ] Show if AutoSysimage is part of the loaded sysimage